### PR TITLE
Fix creation of temporary directory

### DIFF
--- a/src/Sink/ImgArchiveSink.cpp
+++ b/src/Sink/ImgArchiveSink.cpp
@@ -22,6 +22,7 @@
 #include <QRegExp>
 #include <QApplication>
 #include <QDir>
+#include <QTemporaryDir>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -98,23 +99,13 @@ void ImgArchiveSink::init()
 	connect(pinf, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(infoExited(int, QProcess::ExitStatus)));
 	connect(pext, SIGNAL(readyReadStandardOutput()), this, SLOT(extractStdoutReady()));
 	connect(pext, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(extractExited(int, QProcess::ExitStatus)));
+	tmpdir = NULL;
 }
 
 void ImgArchiveSink::doCleanup()
 {
-	if (!tmppath.isEmpty())
-	{
-		QDir dir(tmppath);
-		//
-		// remove temporary files and dirs
-		foreach (const QString f, archfiles)
-			dir.remove(f);
-		foreach (const QString f, archdirs)
-		{
-			dir.rmdir(f);
-		}
-		dir.rmdir(tmppath);
-	}
+	delete tmpdir;
+	tmpdir = NULL;
 }
 
 int ImgArchiveSink::waitForFinished(QProcess *p)
@@ -173,7 +164,7 @@ int ImgArchiveSink::open(const QString &path) //TODO: cleanup if already opened?
 	{
 		if (info.isReadable())
 		{
-                        tmppath = makeTempDir(ComicBookSettings::instance().tmpDir());
+                        const QString tmppath = makeTempDir(ComicBookSettings::instance().tmpDir());
 			archdirs.prepend(tmppath);
                         QStringList extractargs, listargs;
                         ArchiversConfiguration::instance().getExtractArguments(path, extractargs, listargs);
@@ -239,30 +230,9 @@ void ImgArchiveSink::extractStdoutReady()
 
 QString ImgArchiveSink::makeTempDir(const QString &parent)
 {
-    static bool initsrand = false;
-
-    //
-    // make sure srand is called only once
-    if (!initsrand)
-    {
-        srand(time(NULL));
-        initsrand = true;
-    }
-
-    QDir dir(parent);
-    for (;;)
-    {
-        const int n = rand();
-        const QString tmpd = QString("qcomic-") + QString::number(n);
-        if (!dir.exists(tmpd))
-        {
-            if (!dir.mkdir(tmpd))
-            {
-                break;
-            }
-            return parent + QDir::separator() + tmpd;
-        }
-    }
+    tmpdir = new QTemporaryDir(parent + QString("/qcomic-XXXXXX"));
+    if (tmpdir->isValid())
+        return tmpdir->path();
     qFatal("Failed to create temporary directory");
     return QString();
 }

--- a/src/Sink/ImgArchiveSink.h
+++ b/src/Sink/ImgArchiveSink.h
@@ -23,6 +23,7 @@
 #include "ImgDirSink.h"
 
 class QImage;
+class QTemporaryDir;
 
 namespace QComicBook
 {
@@ -37,7 +38,7 @@ namespace QComicBook
 			QProcess *pinf; ///< file list extracing process
 			QString archivename; ///< archive file name, without path
 			QString archivepath; ///< full path, including archive name
-			QString tmppath; ///< path to extracted archive
+			QTemporaryDir *tmpdir; ///< temporary location to extracted archive
 			QStringList archfiles; ///< list of archive files
 			QStringList archdirs; ///< list of archive dirs
 			int filesnum; ///< number of files gathered from parsing archiver output, used for progress bar
@@ -46,6 +47,7 @@ namespace QComicBook
 			static int waitForFinished(QProcess *p);
 			int extract(const QString &filename, const QString &destdir, QStringList extargs, QStringList infargs);
 			void init();
+			QString makeTempDir(const QString &parent);
 			virtual void doCleanup();
 			
 			virtual bool fileHandler(const QFileInfo &finfo);
@@ -69,7 +71,6 @@ namespace QComicBook
 			virtual QString getNext() const;
 			virtual QString getPrevious() const;
 
-			static QString makeTempDir(const QString &parent = QDir::tempPath());
 	};
 }
 


### PR DESCRIPTION
Since QComicBook switched to Qt5, it is posssible to use QTemporaryDir
to create temporary directories: this solves few problems:
- picking a unique random name
- creating safely the directory (so far the temporary directory has been
  readable by anyone, not just the user, leaving a data leak)
- cleanup is done automatically, in the same way, no matter what is the
  structure of the files there

[v2] rebase on latest changes
[v2] https://github.com/stolowski/QComicBook/pull/27